### PR TITLE
Some tests for user-defined meta rules that accept some PEGs as arguments.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,8 +1,7 @@
 on:
   push:
     branches:
-      - main
-      - add-ci # Temporarily used for CI tests.
+      - "*" # Run benchmarks on all branches.
 
 name: Benchmark
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ name: Build, Lint and Test
 
 jobs:
   check:
-    name: Rust project
+    name: Checking
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust toolchain
+      - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: 1.74
@@ -16,6 +16,7 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --all -- --check
       - name: cargo clippy
+        # Add `-Dwarnings` when it's time.
         run: cargo clippy --workspace --all-targets # -- -Dwarnings
       - name: cargo test
         run: cargo test --workspace
@@ -27,16 +28,16 @@ jobs:
     needs: check
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: Checkout Repository
         uses: actions/checkout@v4
-      - name: Install Rust toolchain
+      - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: 1.74
           components: llvm-tools-preview, rustfmt
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
-      - name: Generate code coverage
+      - name: Generate Code Coverage
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Upload Results to Codecov
         uses: codecov/codecov-action@v3
@@ -44,6 +45,8 @@ jobs:
           file: lcov.info
           flags: unittests
           name: pest3-ci-coverage
+          # Failing to upload results will cause a CI error.
+          # So remember to use a token.
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true

--- a/codedov.yml
+++ b/codedov.yml
@@ -1,0 +1,3 @@
+comment:
+  layout: "diff,flags,tree,betaprofiling"
+  show_critical_paths: true

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,4 +1,49 @@
 //! Derive macros implemented with [pest3_generator].
+//!
+//! ## Code Generation
+//!
+//! ### Meta Rules
+//!
+//! Rules can have several arguments.
+//!
+//! Definitions of these rules can use these arguments,
+//! and these rules will be mapped to a struct in Rust using generics.
+//!
+//! ```rust
+//! use pest3_derive::Parser;
+//! use pest3::typed::TypedNode;
+//!
+//! #[derive(Parser)]
+//! #[grammar_inline = r#"
+//!   pair(a, b) = a - " "* - ":" - " "* - b
+//!   string     = "\"" - ('a'..'z' | 'A'..'Z' | '0'..'9')* - "\""
+//!   main       = pair(string, string)
+//! "#]
+//! struct Parser;
+//!
+//! fn main() -> anyhow::Result<()> {
+//!   use rules::*;
+//!   pair::<string, string>::check(r#""a": "b""#)?;
+//!   Ok(())
+//! }
+//! ```
+//!
+//! Once called with some exact parameters,
+//! these arguments are replaced directly as a whole.
+//!
+//! In the example above,
+//! `pair(string, string)` has the same structure with
+//! `string - " "* - ":" - " "* - string`.
+//!
+//! But there are some restrictions on meta rules:
+//!
+//! - All arguments must be used.
+//!   I think there is no reason in pest for one to define an argument
+//!   that won't be used, at least for now.
+//!
+//! And later we may support constant arguments
+//! just like the built-in rule `pest::stack::peek`.
+
 #![warn(rust_2018_idioms, rust_2021_compatibility, missing_docs)]
 
 use proc_macro::TokenStream;

--- a/derive/tests/meta_rules.rs
+++ b/derive/tests/meta_rules.rs
@@ -33,5 +33,10 @@ fn main() -> Result<()> {
         to_json("123,456\n789,abc")?,
         json!([["123", "456"], ["789", "abc"]])
     );
+    assert!(to_json("").is_err());
+    assert!(to_json("123,").is_err());
+    assert!(to_json("123,456,").is_err());
+    assert!(to_json("123\n").is_err());
+    assert!(to_json("123,\n456").is_err());
     Ok(())
 }

--- a/derive/tests/meta_rules.rs
+++ b/derive/tests/meta_rules.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use pest3::typed::TypedParser;
+use pest3_derive::Parser;
+use serde_json::{json, Value};
+use std::iter::once;
+
+#[derive(Parser)]
+#[grammar_inline = r#"
+separated(i, sep) = i - (sep - i)*
+cell              = ('a'..'z' | 'A'..'Z' | '0'..'9' | ".")+
+main              = separated(separated(cell, " "* - "," - " "*), "\n")
+"#]
+struct Parser;
+
+fn to_json(input: &str) -> Result<Value> {
+    let file = Parser::try_parse::<rules::main>(input)?;
+    let (first, following) = file.separated().i();
+    let lines = once(first).chain(following);
+    let lines = lines.map(|line| {
+        let (first, following) = line.i();
+        let cells = once(first).chain(following);
+        let cells = cells.map(|cell| Value::String(cell.span.as_str().to_owned()));
+        Value::Array(cells.collect())
+    });
+    let res = Value::Array(lines.collect());
+    Ok(res)
+}
+
+#[test]
+fn main() -> Result<()> {
+    assert_eq!(to_json("123,456")?, json!([["123", "456"]]));
+    assert_eq!(
+        to_json("123,456\n789,abc")?,
+        json!([["123", "456"], ["789", "abc"]])
+    );
+    Ok(())
+}


### PR DESCRIPTION
This adds some tests about meta rules. Only meta rules that accept PEGs can be defined by users currently, and users can't define a rule that accepts a slice (like `pest::stack::peek`).

An example that is tested:

```
separated(i, sep) = i - (sep - i)*
cell()            = ('a'..'z' | 'A'..'Z' | '0'..'9' | ".")+
main              = separated(separated(cell, " "* - "," - " "*), "\n")
```

This solves a part of <https://github.com/pest-parser/pest3/issues/8>.

And this PR includes some updates about CI, as previous PR doesn't actually enable benchmarking correctly.