### PR TITLE
Newline problem on windows

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+newline_style="Unix"


### PR DESCRIPTION
The tests of the generator crate use `rustfmt` to format a string taken from a TokenStream.
On Windows `rustfmt` uses a carriage return followed by a line feed for separting lines.
Because the tests check if the generated and formatted files are the same as the expected ones bit by bit, it makes all test fail on the Windows platform.

Instead of adding a `rustfmt.toml`, if for some reason that is not wanted, a warning/requirement can be given in a CONTRIBUTING.md.