### PR TITLE
fix handling of very long sequences/choices

### DIFF
--- a/core/src/choice.rs
+++ b/core/src/choice.rs
@@ -100,6 +100,8 @@ macro_rules! choice_type {
     };
 }
 
+pub use choice_type;
+
 choice_type! {
     Choice2,
     (Choice0, T0, choice_0),

--- a/core/src/sequence.rs
+++ b/core/src/sequence.rs
@@ -100,6 +100,8 @@ macro_rules! sequence_type {
     };
 }
 
+pub use sequence_type;
+
 sequence_type! {
     Sequence2,
     (field_0, T0, TR0),

--- a/derive/tests/grammar.pest
+++ b/derive/tests/grammar.pest
@@ -47,7 +47,12 @@ pop_ = pest::stack::push(range) - pest::stack::push(range) - pest::stack::pop - 
 pop_all = pest::stack::push(range) - pest::stack::push(range) - pest::stack::pop_all
 pop_fail = pest::stack::push(range) - !pest::stack::pop - range - pest::stack::pop
 checkpoint_restore = pest::stack::push("") - (pest::stack::push("a") - "b" - pest::stack::pop | pest::stack::drop - "b" | pest::stack::pop - "a") - pest::EOI
-
+longchoice_builtin = ( "01" | "02" | "03" | "04" | "05" | "06" | "07" | "08" | "09" | "10" | "11" | "12" | "13" | "14" | "15" | "16")
+longseq_builtin = ( "01" ~ "02" ~ "03" ~ "04" ~ "05" ~ "06" ~ "07" ~ "08" ~ "09" ~ "10" ~ "11" ~ "12" ~ "13" ~ "14" ~ "15" ~ "16")
+longchoice_critical = ( "01" | "02" | "03" | "04" | "05" | "06" | "07" | "08" | "09" | "10" | "11" | "12" | "13" | "14" | "15" | "16" | "17")
+longseq_critical = ( "01" ~ "02" ~ "03" ~ "04" ~ "05" ~ "06" ~ "07" ~ "08" ~ "09" ~ "10" ~ "11" ~ "12" ~ "13" ~ "14" ~ "15" ~ "16" ~ "17")
+longchoice_jump = ( "01" | "02" | "03" | "04" | "05" | "06" | "07" | "08" | "09" | "10" | "11" | "12" | "13" | "14" | "15" | "16" | "17" | "18" | "19")
+longseq_jump = ( "01" ~ "02" ~ "03" ~ "04" ~ "05" ~ "06" ~ "07" ~ "08" ~ "09" ~ "10" ~ "11" ~ "12" ~ "13" ~ "14" ~ "15" ~ "16" ~ "17" ~ "18" ~ "19")
 /*
 ascii_digits = ASCII_DIGIT+
 ascii_nonzero_digits = ASCII_NONZERO_DIGIT+


### PR DESCRIPTION
Looking at code for sequences and choices it looked like sequences and choices were limited to at most 16.
Turns out the generator was already auto-generating types for longer cases, but there were two small things breaking it.
First was an off by one typo, skipping the built-ins `Sequence16` and `Choice16`.
The other is due to some inconsistency between the calls to the generating macros and the spec of these macros.

I added a test case in `derive/tests/grammar.pest`